### PR TITLE
fix: cleaned up resource allocation, state update from single thread

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,2 +1,8 @@
 nice to have:
 - support battery removal/reinsertion on the fly
+- if no battery, then 
+    - manage period = WD/8
+    - go through the  initial states after each manage period until battery is detected
+
+- if battery is removed
+  - charging state is Trickle with 0 Ibat => battery removed event


### PR DESCRIPTION
 - devm auto cleanup for each resouce
 - managing charger from a single worker thread regardless of IRQ or WD timer
 - added force charge enable/ disable sysfs entries
 - fixed initial battery capacity reporting race condition